### PR TITLE
rename install targets to sneedacity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,8 +284,8 @@ set( _DEST "${_DESTDIR}" )
 set( _PREFIX "${CMAKE_INSTALL_PREFIX}" )
 set( _LIBDIR "${CMAKE_INSTALL_LIBDIR}" )
 set( _DATADIR "${CMAKE_INSTALL_DATADIR}" )
-set( _PKGLIB "${_LIBDIR}/audacity" )
-set( _PKGDATA "${_DATADIR}/audacity/" )
+set( _PKGLIB "${_LIBDIR}/sneedacity" )
+set( _PKGDATA "${_DATADIR}/sneedacity/" )
 set( _MANDIR "${CMAKE_INSTALL_MANDIR}" )
 set( _MODDIR "${_DEST}/modules" )
 set( _EXEDIR "${_DEST}" )
@@ -450,9 +450,9 @@ endif()
 
 # Define Audacity's name
 if( CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows" )
-   set( AUDACITY_NAME "Audacity" )
+   set( AUDACITY_NAME "Sneedacity" )
 else()
-   set( AUDACITY_NAME "audacity" )
+   set( AUDACITY_NAME "sneedacity" )
 endif()
 
 # Create short and full version strings


### PR DESCRIPTION
renames some more targets like binary and libs. we can go all the way and do opt prefix (the `audacity_` stuff you can pass) but then I have to change the package again