### PR TITLE
repaired github workload script

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -13,8 +13,8 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     env:
-      AUDACITY_CMAKE_GENERATOR: ${{ matrix.config.generator }}
-      AUDACITY_ARCH_LABEL: ${{ matrix.config.arch }}
+      SNEEDACITY_CMAKE_GENERATOR: ${{ matrix.config.generator }}
+      SNEEDACITY_ARCH_LABEL: ${{ matrix.config.arch }}
       # Windows codesigning
       # This variables will be used by all the steps
       WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}

--- a/scripts/ci/linux/split_debug_symbols.sh
+++ b/scripts/ci/linux/split_debug_symbols.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -x
+objcopy --only-keep-debug --compress-debug-section=zlib "${1}" "${1}.debug"
+if [ -f "${1}.debug" ]; then
+    objcopy --strip-debug --strip-unneeded "${1}"
+    objcopy --add-gnu-debuglink="${1}.debug" "${1}"
+fi
+


### PR DESCRIPTION
I repaired the github workload script.
Check [my test](https://github.com/meguminloli/sneedacity/actions/runs/1003775269). Someone removed the linux script from `scripts/ci/linux` so that's why it couldn't compile on Loonix. Also, looks like you forgot to change the name of the build architecture from `scripts/ci/configure.sh`.
I tried it the linux build, it builds an appimage, and it works on gentoo. I didn't try windows and mac builds tho.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
