### PR TITLE
Update readme to reflect a more accurate description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Sneedacity](https://i.ibb.co/ZcCxtsB/sneeddabphones.gif)
 =========================
 
-**Sneedacity** is an easy-to-use, multi-track audio editor and recorder for Windows, Mac OS X, GNU/Linux and other operating systems. Sneedacity is open source software licensed under GPL, version 2 or later.
+**Sneedacity** (formerly Audacity) is an easy-to-use, multi-track audio editor and recorder for Windows, Mac OS X, GNU/Linux and other operating systems. Sneedacity is open source software licensed under GPL, version 2 or later.
 
 - **Recording** from any real, or virtual audio device that is available to the host system.
 - **Export / Import** a wide range of audio formats, extendible with FFmpeg.


### PR DESCRIPTION
Changes Sneedacity to Sneedacity (formerly Audacity) in the readme. 