### PR TITLE
replaced audacity with sneedacity in ci build

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
-        name: Audacity_${{ matrix.config.name }}_${{ github.run_id }}_${{ env.GIT_HASH_SHORT }}
+        name: Sneedacity_${{ matrix.config.name }}_${{ github.run_id }}_${{ env.GIT_HASH_SHORT }}
         path: |
           build/package/*
           !build/package/_CPack_Packages


### PR DESCRIPTION
*(short description of the changes and the motivation to make the changes)*
Looks like I forgot to replace Audacity with Sneedacity in Artifacts name. I kept audacity in `github.repository_owner == 'audacity'` because we don't have apple certificates, so that is not gonna trigger. 
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
