### PR TITLE
patched sloppy Wrapper.c code that allowed buffer overruns

### DIFF
--- a/mac/Wrapper.c
+++ b/mac/Wrapper.c
@@ -4,7 +4,7 @@
 
   Wrapper.c
 
-  Sneedacity(R) is copyright (c) 2020-2020 Sneedacity Team.
+  Sneedacity(R) is copyright (c) 2020-2021 Sneedacity Team.
   License: GPL v2.  See License.txt.
 
 *******************************************************************//**
@@ -28,20 +28,22 @@ executable.
 #include <string.h>
 #include <unistd.h>
 
+#define SNEEDACITY_LEN 11
 static const char sneedacity[] = "Sneedacity";
 extern char **environ;
 
 int main(int argc, char *argv[])
 {
-   size_t len = strlen(argv[0]);
-   char *path = alloca(len + sizeof(sneedacity)); // not precise, but we don't need it to be
-
-   strcpy(path, argv[0]);
+   size_t len = strnlen(argv[0], 256) + 1, // to account for terminating char
+          exlen = len + SNEEDACITY_LEN;
+          
+   char *path = alloca(exlen);
+   strncpy(path, argv[0], len);
 
    char *slash = strrchr(path, '/');
    if (slash)
    {
-      strcpy(++slash, sneedacity);
+      strncpy(++slash, sneedacity, exlen);
    }
 
    unsetenv("DYLD_LIBRARY_PATH");


### PR DESCRIPTION
In mac/Wrapper.c, alloca is used to allocate to the stack frame, meanwhile cringe funcs like strcpy and strlen were used. Delimiting has been applied.

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
