### PR TITLE
revert brand change on todo.txt

### DIFF
--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,6 @@
 todo.txt
 
-See also the Sneedacity Bugzilla for some logged enhancement issues:
+See also the Audacity Bugzilla for some logged enhancement issues:
 http://tinyurl.com/32udrem
 
 and ideas on Feature Requests:
@@ -39,7 +39,7 @@ Only the Selector tool can set the cursor, right?
 Multitool should be considered as a base for the default mode.
 Some operations would work always, like making a selection.
 Then various tools would change function of some of the mouse
-buttons. Without the multitool the Sneedacity is very annoying to
+buttons. Without the multitool the Audacity is very annoying to
 use, IMHO.   JS]
 
 * More built-in code for automated testing, not sure exactly what,
@@ -51,7 +51,7 @@ its paces, capturing .pngs of toolbars, sliders, dialogs according to
 an external script file.  This makes updating the images in the
 documentation much easier.
 [ Third party screen capture program which accepts remote commands
-via a named pipe, say. Sneedacity would then have a way to send one
+via a named pipe, say. Audacity would then have a way to send one
 command only and a way to send commands repeatedly (n times per
 minute). ]
 
@@ -153,8 +153,8 @@ UI::
   and the export doesn't require any mixing, mark the project
   as not dirty (i.e. don't ask if they want to save it).
 - Put close box in toolbar.
-- Import... should be able to import Sneedacity projects
-  and Sneedacity project files
+- Import... should be able to import Audacity projects
+  and Audacity project files
 - Adapt text color - should be white by default if
   the background color is very dark
 - Invert selection (for now, until we allow discontiguous selections,

--- a/todo.txt
+++ b/todo.txt
@@ -1,193 +1,20 @@
-todo.txt
+This was an old file documenting some features that Audacity wanted
+to implement before the Muse Group mess. We might want to implement
+these as well. Or have them merged to upstream and backport it to
+our fork.
 
-See also the Audacity Bugzilla for some logged enhancement issues:
-http://tinyurl.com/32udrem
+Audacity (upstream) Bugzilla for some logged enhancement issues:
+https://tinyurl.com/32udrem
 
-and ideas on Feature Requests:
-http://wiki.audacityteam.org/wiki/Feature_Requests
+Ideas on Feature Requests:
+https://wiki.audacityteam.org/wiki/Feature_Requests
 
-Some other useful ideas may still be be found on:
-http://wiki.audacityteam.org/wiki/Release_checklist_not_aiming_for_1.4
+This one is super-old, but might contain some things that are useful:
+https://wiki.audacityteam.org/wiki/Release_checklist_not_aiming_for_1.4
 
-Residual things from the past still undone as at end-2012:
+For residual things from the past still undone as at end-2012, see
+upstream's todo.txt at: 
+https://github.com/audacity/audacity/blob/master/todo.txt
 
-* Allow the user to create keyboard shortcuts to run an effect 
-  using particular parameters.
-
-* Support custom cursors on Mac.
-
-* A master gain control, if at all possible
-
-* When a selection is readjusted by grab&drag, the release of the
-button at outside of the track panel could mean "undo".
-Similar for all other operations.
-
-* dragging the selection edge out of display starts moving the
-wave, but moving could start 100 or so pixels before the display
-edge so that the coming wave can be seen
-
-* A bars/beats time ruler and snap-to bars/beats.
-
-  (Karl, if you want to submit a patch, it's fine with me,
-  as long as it's complete and clean.)
-
-* In the Timeshift-tool mode I propose making [ctrl+mb1] do
-"Align track to cursor". Since they're only one clip per track,
-simply clicking anywhere in to the track should perform that function.
-Only the Selector tool can set the cursor, right?
-[ Checking the mouse button operations through should be done.
-Multitool should be considered as a base for the default mode.
-Some operations would work always, like making a selection.
-Then various tools would change function of some of the mouse
-buttons. Without the multitool the Audacity is very annoying to
-use, IMHO.   JS]
-
-* More built-in code for automated testing, not sure exactly what,
-ideas for how to do this would be welcome.
-[ It is more like continuous research job.]
-
-* Related to this, a self-image-capture class. This puts the gui through
-its paces, capturing .pngs of toolbars, sliders, dialogs according to
-an external script file.  This makes updating the images in the
-documentation much easier.
-[ Third party screen capture program which accepts remote commands
-via a named pipe, say. Audacity would then have a way to send one
-command only and a way to send commands repeatedly (n times per
-minute). ]
-
-* Track label could be changed to look like what is in commercial
-multitrack software. More compact, that is.  JS.
-
-  [I don't think we should necessarily copy the commercial software
-   in this regard.  I hate most of their UIs because they force me
-   to memorize what tiny little symbols and colors mean.  I like
-   my UIs to be "discoverable".  DM]
-  [Agree with DM about not simply copying and discoverability.
-  Agree with JS that more compact ways to do Track Label need 
-  investigation.  Screen real estate is valuable.  JKC]
-
-------------------------------------------------------
- Unclear - what are these?
-------------------------------------------------------
-
-* In zoom mode, scrollwheel click acts as middle button click, but when
-dragging with it, it behaves strangely (I couldn't figure out the logic)
-Also rmb dragging behaviour is strange. As lmb dragging is intuitive, I
-assumed that dragging small area with rmb would zoom out a lot,
-and dragging bigger areas would zoom out less.
-
-------------------------------------------------------
- More far-future ideas
-------------------------------------------------------
-
-[JKC] L&R <-> Average+Difference display. This way you can see 
-what a stereo track gets mixed down to as mono, and the stereo 
-content separately.
-
-[JKC] Split Track into band pass filtered components. Useful 
-even just to view a waveform without background mains hum.
-[JS] Spectrogram would do that already?  
-[JKC] No.  This is a split of the actual waveform into two 
-components which sum to the original.
-
-
-[JKC] Audio Diff: Ability to compare waveforms and have this 
-displayed graphically. 
-See http://wiki.audacityteam.org/wiki/Proposal_Audio_Diff .
-[JS] Can a plug-in operate on two tracks and generate preview to
-third track? Or replace the second track with the result.
-It would be essential that the subtraction between two tracks
-is made interactively so that user may time-shift the waveforms
-and manually find the alignment between the tracks.
-This may go far future if it requires changes to plug-in system.
-[JKC] I have in mind something more like Unix diff that compares 
-and aligns waveforms.  Useful when you have several takes of 
-the same track.
-
-* Extend "On-Demand" importing of audio with UI to 
-  compressed audio formats  
-
------------------------------------------------------------
-Here's an older list of items.  Things we've already done
-have been removed, so these are all still valid ideas.
------------------------------------------------------------
-
-- Upload some icons for people to use with
-  KDE, GNOME, WindowMaker, AfterStep, BlackBox...
-
-- Do "preflight" check of disk space before editing
-  operations.
-
-- Help the user find missing project _folder.
-
-- Smart Record features:
-  - Control latency
-  - Use as little CPU power as possible
-  - Detect dropped samples using many different methods
-  - Visually show buffer sizes
-  - Multi-channel record
-  - Show remaining disk space
-  - Includes higher-quality recording (because of extremely limited
-  GUI operations), timed recording, large VU meters, and more.
-  All of the recording options that are too complicated to do
-  with the normal record button (in the future: record directly to 
-  MP3/Ogg, and add pre-roll and post-roll to volume-triggered 
-  recording). 
-
-* For pre- and post-roll (amount to play before and after a selection),
-  see DG Malham email - Please add date so can check the archives for it.
-
-UI::
-- Turn off autoscrolling if the user manually hits the scroll bar.
-- Label the "Left" and "Right" channels!
-- Small toolbar option
-- Create our own progress dialog:
-  - Improved time estimate
-- A "mini view" of the whole project, which shows what part
-  you're working on, etc. like a lot of other programs have
-- Visual track dragging
-- Split at labels
-- Improve Save prompt dialogs: use "Save", "Don't Save", and
-  include the name of the file.
-- When a user exports the entire project (in any format)
-  and the export doesn't require any mixing, mark the project
-  as not dirty (i.e. don't ask if they want to save it).
-- Put close box in toolbar.
-- Import... should be able to import Audacity projects
-  and Audacity project files
-- Adapt text color - should be white by default if
-  the background color is very dark
-- Invert selection (for now, until we allow discontiguous selections,
-                    this should mean two options: select up to selection,
-                    and select after selection)
-- Legend (Ruler) for Pitch 
-- A way to turn a track into a loop.  It would be cool if the
-  display showed the "real" waveform once, and then "ghosts" of
-  that waveform repeating forever...  (We now have a loop-play
-  using shift-play which goes some way to answering this request).
-- Scrubbing, where you hear the track speeded up as you drag 
-  the play marker.
-   
-Import/Export::
-- Import/Export markers in WAV files (like Goldwave does - 
-  see email from Shane M.  - Please add date so can check archives.)
-
-Effects::
-- Add real-time effects directly to tracks (see Ezequiel 5/10/2002)
-- Freeverb 3.0 (and better interface), or native port of it or
-  otherwise improve reverb.
-- Smart Mix (like Quick Mix but guarantees no clipping)
-- Cross-fade (smooth between two tracks) 
-- Save VST plug-in parameters to a file, or at least
-  remember the last settings
-
------------------------------------------------------------
-Future:
------------------------------------------------------------
-
-- Speed issues especially with longer projects: http://tinyurl.com/c6qcehm 
-- Edit markers on waveform (as distinct from cut and split lines)
-- discontiguous selection
-- visualization window: VU meters, equalizer, continuous waveform, oscilloscope
-- Configurable mouse bindings and investigate horizontal-scrolling-
-   without-SHIFT-modifier support in wxWidgets 2.9
+They might no longer be applicable in 3.0.x though. The todo.txt in
+upstream (as of writing) was last updated in 2012 after all.


### PR DESCRIPTION
These are todos dating back to 2012, so doesn't make sense to rename to Sneedacity.