### PR TITLE
fully implemented 4chan easter egg (for windows) as requested by issue #103

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,6 +133,8 @@ list( APPEND SOURCES
       Diags.h
       Dither.cpp
       Dither.h
+      EasterEgg.cpp
+      EasterEgg.h
       Envelope.cpp
       Envelope.h
       EnvelopeEditor.cpp

--- a/src/EasterEgg.cpp
+++ b/src/EasterEgg.cpp
@@ -15,20 +15,18 @@ selecting a track will bring you to the /g/ catalog.
 
 *//*******************************************************************/
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(WIN32)
 
 #include <Windows.h>
 #include "EasterEgg.h"
 
 // this char array must be declared as int or else GetAsyncKeyState won't work
 const int gEasterEggSteps[] = {'S', 'N', 'E', 'E', 'D'};
-bool gEasterEggDone = false,
-	 gEasterEggMutex = false;
+bool gEasterEggDone = false;
+bool gEasterEggMutex = false;
 
 void EasterEgg::CheckIfSneed(void)
 {
-	// wxwidgets does not have an quick way of checking individual keyup/keydown states
-	// so I'll have to use a win32 specific function here :/
 
 	for (int i = 0;i <= 4;i++) {
 		int current = gEasterEggSteps[i];

--- a/src/EasterEgg.cpp
+++ b/src/EasterEgg.cpp
@@ -1,0 +1,63 @@
+/**********************************************************************
+
+  Sneedacity: A Digital Audio Editor
+
+  EasterEgg.cpp
+
+  moxniso
+
+*******************************************************************//**
+
+\class EasterEgg
+
+\brief An easter egg in Sneedacity whereby typing "sneed" after 
+selecting a track will bring you to the /g/ catalog.
+
+*//*******************************************************************/
+
+#ifdef _WIN32
+
+#include <Windows.h>
+#include "EasterEgg.h"
+
+// this char array must be declared as int or else GetAsyncKeyState won't work
+const int gEasterEggSteps[] = {'S', 'N', 'E', 'E', 'D'};
+bool gEasterEggDone = false,
+	 gEasterEggMutex = false;
+
+void EasterEgg::CheckIfSneed(void)
+{
+	// wxwidgets does not have an quick way of checking individual keyup/keydown states
+	// so I'll have to use a win32 specific function here :/
+
+	for (int i = 0;i <= 4;i++) {
+		int current = gEasterEggSteps[i];
+		if (GetAsyncKeyState(current) & 0x8000) {
+			if (((current == 'S') && (mEasterEggStagesCompleted >= 1)) ||
+				((current == 'N') && (mEasterEggStagesCompleted >= 2)) ||
+			    ((current == 'E') && (mEasterEggStagesCompleted >= 4)))
+					break;
+			
+			this->mEasterEggStagesCompleted++;
+		}
+	}
+			
+	if (this->mEasterEggStagesCompleted >= 5) 
+	{
+		if (!gEasterEggDone) // to stop multiple tabs from appearing
+			wxLaunchDefaultBrowser((wxString)"https://4chan.org/g/sneed");
+		
+		gEasterEggDone = true;
+	}
+}
+
+EasterEgg::EasterEgg() 
+{
+	this->mEasterEggStagesCompleted = 0;
+}
+
+EasterEgg::~EasterEgg()
+{
+}
+
+#endif // _WIN32

--- a/src/EasterEgg.h
+++ b/src/EasterEgg.h
@@ -1,0 +1,53 @@
+/**********************************************************************
+
+  Sneedacity: A Digital Audio Editor
+
+  EasterEgg.h
+
+  moxniso
+
+*******************************************************************//**
+
+\class EasterEggThread
+
+\brief wxThread inheritor for "SNED" easter egg
+
+*//*******************************************************************/
+
+#ifdef _WIN32
+
+#pragma once
+#include <wx/thread.h>
+#include <wx/utils.h>
+
+extern bool gEasterEggDone,
+			gEasterEggMutex;
+
+class EasterEgg {
+public:
+	EasterEgg();
+	~EasterEgg();
+	void CheckIfSneed();
+
+	int mEasterEggStagesCompleted;
+};
+
+class EasterEggStartChecking : public wxThread {
+public:
+	EasterEggStartChecking() = default;
+	~EasterEggStartChecking() = default;
+
+	void *Entry()
+	{
+		EasterEgg once;
+		while (!gEasterEggDone)
+			once.CheckIfSneed();
+		
+		gEasterEggMutex = false;
+		gEasterEggDone = false;
+		return NULL;
+	}
+
+};
+
+#endif // _WIN32

--- a/src/EasterEgg.h
+++ b/src/EasterEgg.h
@@ -8,20 +8,15 @@
 
 *******************************************************************//**
 
-\class EasterEggThread
-
-\brief wxThread inheritor for "SNED" easter egg
-
 *//*******************************************************************/
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(WIN32)
 
-#pragma once
 #include <wx/thread.h>
 #include <wx/utils.h>
 
-extern bool gEasterEggDone,
-			gEasterEggMutex;
+extern bool gEasterEggDone;
+extern bool gEasterEggMutex;
 
 class EasterEgg {
 public:

--- a/src/SelectionState.cpp
+++ b/src/SelectionState.cpp
@@ -12,6 +12,7 @@
 #include "ViewInfo.h"
 #include "Track.h"
 #include "Project.h"
+#include "EasterEgg.h"
 
 static const SneedacityProject::AttachedObjects::RegisteredFactory key{
   [](SneedacityProject &){ return std::make_shared< SelectionState >(); }
@@ -59,6 +60,15 @@ void SelectionState::SelectTrack(
 
    if (updateLastPicked)
       mLastPickedTrack = track.SharedPointer();
+
+#ifdef _WIN32
+   if (!gEasterEggMutex) 
+   {
+	   gEasterEggMutex = true;
+	   wxThread *typed_sneed = new EasterEggStartChecking();
+	   typed_sneed->Run();
+   }
+#endif
 
 //The older code below avoids an anchor on an unselected track.
 

--- a/src/SelectionState.cpp
+++ b/src/SelectionState.cpp
@@ -61,7 +61,7 @@ void SelectionState::SelectTrack(
    if (updateLastPicked)
       mLastPickedTrack = track.SharedPointer();
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(WIN32)
    if (!gEasterEggMutex) 
    {
 	   gEasterEggMutex = true;


### PR DESCRIPTION
issue #103 asked for an easter egg where, after selecting a track, the user would type "sneed" and
they'd be brought to /g/. It has now been implemented for Windows builds of Sneedacity.

All that needs to be replaced in order for this to work on Linux and Mac is the call to
the win32 function GetAsyncKeyState(). I had to use it since wxwidgets doesn't seem to have
an builtin way to check normal key states. 

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
