### PR TITLE
[lib-src/porfsmf] include <cstring>

### DIFF
--- a/lib-src/portsmf/allegro.h
+++ b/lib-src/portsmf/allegro.h
@@ -49,6 +49,7 @@
 #ifndef ALLEGRO_H
 #define ALLEGRO_H
 #include <assert.h>
+#include <cstring>
 #include <istream>
 #include <ostream>
 


### PR DESCRIPTION
for /lib-src/portsmf/allegro.h:602:33:

Resolves: this error while building lib-src
```
/lib-src/portsmf/allegro.h:602:33: error: ‘strlen’ was not declared in this scope
  602 |                          ptr += strlen(s);
      |                                 ^~~~~~
/lib-src/portsmf/allegro.h:52:1: note: ‘strlen’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
```



