### PR TITLE
reimplemented /g/ catalog feature requested by issue #103

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,8 @@ list( APPEND SOURCES
       BatchProcessDialog.h
       Benchmark.cpp
       Benchmark.h
+      Catalog.cpp
+      Catalog.h
       CellularPanel.cpp
       CellularPanel.h
       ClassicThemeAsCeeCode.h

--- a/src/Catalog.cpp
+++ b/src/Catalog.cpp
@@ -1,0 +1,49 @@
+/**********************************************************************
+
+  Sneedacity: A Digital Audio Editor
+
+  Catalog.cpp
+
+  moxniso
+
+*******************************************************************//**
+
+\class Catalog
+
+\brief An easter egg in Sneedacity whereby typing "sneed" after 
+selecting a track will bring you to the /g/ catalog. As this is technically
+telemetry, it is disabled by default, and must be enabled manually in Preferences.
+
+*//*******************************************************************/
+
+#include <wx/wx.h>
+#include "Catalog.h"
+#include "Prefs.h"
+
+const int gCatalogSteps[] = {'S', 'N', 'E', 'E', 'D'};
+int gCatalogStepsCompleted = 0;
+
+void CatalogListener::CheckForSneed(wxKeyEvent& kev)
+{
+	bool enabled;
+	gPrefs->Read(wxT("/GUI/Catalog"), &enabled);
+	
+	if (enabled) 
+	{
+		for (int i = 0; i <= 4; i++) {
+			if (kev.GetKeyCode() == gCatalogSteps[gCatalogStepsCompleted]) {
+				gCatalogStepsCompleted++;
+				break;
+			}
+		}
+
+		if (gCatalogStepsCompleted >= 5) {
+			gCatalogStepsCompleted = 0;
+			wxLaunchDefaultBrowser((wxString)"https://4chan.org/g/sneed");
+		}
+
+		kev.ResumePropagation(1);
+		kev.Skip();
+	}
+}
+

--- a/src/Catalog.cpp
+++ b/src/Catalog.cpp
@@ -41,9 +41,9 @@ void CatalogListener::CheckForSneed(wxKeyEvent& kev)
 			gCatalogStepsCompleted = 0;
 			wxLaunchDefaultBrowser((wxString)"https://4chan.org/g/sneed");
 		}
-
-		kev.ResumePropagation(1);
-		kev.Skip();
 	}
+
+	kev.ResumePropagation(1);
+	kev.Skip();
 }
 

--- a/src/Catalog.h
+++ b/src/Catalog.h
@@ -1,0 +1,18 @@
+/**********************************************************************
+
+  Sneedacity: A Digital Audio Editor
+
+  Catalog.h
+
+  moxniso
+
+*******************************************************************//**
+
+*//*******************************************************************/
+
+#pragma once
+
+class CatalogListener : public wxEvtHandler {
+public:
+	void CheckForSneed(wxKeyEvent& kev);
+};

--- a/src/Catalog.h
+++ b/src/Catalog.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <wx/event.h>
+
 class CatalogListener : public wxEvtHandler {
 public:
 	void CheckForSneed(wxKeyEvent& kev);

--- a/src/SneedacityApp.cpp
+++ b/src/SneedacityApp.cpp
@@ -77,6 +77,7 @@ It handles initialization and termination by subclassing wxApp.
 #include "AudioIO.h"
 #include "Benchmark.h"
 #include "Clipboard.h"
+#include "Catalog.h"
 #include "CrashReport.h" // for HAS_CRASH_REPORT
 #include "commands/CommandHandler.h"
 #include "commands/AppCommandEvent.h"
@@ -791,6 +792,7 @@ BEGIN_EVENT_TABLE(SneedacityApp, wxApp)
 
    // Global ESC key handling
    EVT_KEY_DOWN(SneedacityApp::OnKeyDown)
+   EVT_KEY_DOWN(CatalogListener::CheckForSneed) // setup "sneed" event listener
 END_EVENT_TABLE()
 
 // backend for OnMRUFile

--- a/src/SneedacityApp.h
+++ b/src/SneedacityApp.h
@@ -16,6 +16,7 @@
 
 
 #include "Identifier.h"
+#include "Catalog.h"
 
 
 
@@ -99,6 +100,7 @@ class SneedacityApp final : public wxApp {
    std::unique_ptr<wxSingleInstanceChecker> mChecker;
 
    wxTimer mTimer;
+   CatalogListener once;
 
    void InitCommandHandler();
 

--- a/src/prefs/GUIPrefs.cpp
+++ b/src/prefs/GUIPrefs.cpp
@@ -187,6 +187,10 @@ void GUIPrefs::PopulateOrExchange(ShuttleGui & S)
       S.TieCheckBox(XXO("Show e&xtra menus"),
                     {wxT("/GUI/ShowExtraMenus"),
                      false});
+	  S.TieCheckBox(XXO("Enable /g/ catalog command"),
+                    {wxT("/GUI/Catalog"),
+                     false});
+
 #ifdef EXPERIMENTAL_THEME_PREFS
       // We do not want to make this option mainstream.  It's a 
       // convenience for developers.


### PR DESCRIPTION
I've revised the code I proposed in PR #116 and made significant improvements

-A proper wxKeyEvent listener is now used, AsyncGetKeyState and any multithreading was removed
-Global namespace pollution was removed
-Renamed EasterEgg.cpp to Catalog.cpp so it sounds less cringe
-The feature itself is now disabled by default, since it can be classified as telemetry given it pings 4channel,
  so you must enable it in Preferences -> Interface.
-Catalog::CheckForSneed has been completely refactored

This was tested on Windows 10 and Ubuntu 19.04, and it works as expected on both.