### PR TITLE
Add toolbar locking

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -926,6 +926,9 @@ AdornedRulerPanel::AdornedRulerPanel(SneedacityProject* project,
    mTracks = &TrackList::Get( *project );
 
    mIsSnapped = false;
+   mEditMode = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), true);
+
+   mGrabber = nullptr;
 
    mIsRecording = false;
 
@@ -969,7 +972,13 @@ void AdornedRulerPanel::Refresh( bool eraseBackground, const wxRect *rect )
 
 void AdornedRulerPanel::UpdatePrefs()
 {
-   if (mNeedButtonUpdate) {
+   bool mode = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), true);
+   
+   if ( mode != mEditMode )
+   {
+      mEditMode = mode;
+      ReCreateButtons();
+   }else if (mNeedButtonUpdate) {
       // Visit this block once only in the lifetime of this panel
       mNeedButtonUpdate = false;
       // Do this first time setting of button status texts
@@ -1009,6 +1018,12 @@ void AdornedRulerPanel::ReCreateButtons()
       button = nullptr;
    }
 
+   if ( mGrabber )
+   {
+      mGrabber->Destroy();
+      mGrabber = nullptr;
+   }
+
    size_t iButton = 0;
    // Make the short row of time ruler pushbottons.
    // Don't bother with sizers.  Their sizes and positions are fixed.
@@ -1017,12 +1032,14 @@ void AdornedRulerPanel::ReCreateButtons()
 
    wxPoint position( 1, 0 );
 
-   Grabber * pGrabber = safenew Grabber(this, this->GetId());
-   pGrabber->SetAsSpacer( true );
-   //pGrabber->SetSize( 10, 27 ); // default is 10,27
-   pGrabber->SetPosition( position );
-
-   position.x = 12;
+   if ( mEditMode )
+   {
+      mGrabber = safenew Grabber(this, this->GetId());
+      mGrabber->SetAsSpacer( true );
+      //mGrabber->SetSize( 10, 27 ); // default is 10,27
+      mGrabber->SetPosition( position );
+      position.x = 12;
+   }else position.x = 0;
 
    auto size = theTheme.ImageSize( bmpRecoloredUpSmall );
    size.y = std::min(size.y, GetRulerHeight(false));

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -5,6 +5,10 @@
   AdornedRulerPanel.cpp
 
   Dominic Mazzoni
+  
+  Copyright (C) 2021 https://github.com/abb128
+  Copyright (C) 1999-2021 Audacity Team
+  Licensed under the GNU GPL v3+
 
 *******************************************************************//**
 

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -13,6 +13,7 @@
 
 #include "CellularPanel.h"
 #include "widgets/Ruler.h" // member variable
+#include "widgets/Grabber.h" // mGrabber
 #include "Prefs.h"
 #include "ViewInfo.h" // for PlayRegion
 
@@ -142,6 +143,9 @@ private:
    double mQuickPlayPos;
 
    bool mIsSnapped;
+   bool mEditMode;
+
+   Grabber *mGrabber;
 
    PlayRegion mOldPlayRegion;
 

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -6,6 +6,10 @@
 
   Dominic Mazzoni
 
+  Copyright (C) 2021 https://github.com/abb128
+  Copyright (C) 1999-2021 Audacity Team
+  Licensed under the GNU GPL v3+
+
 **********************************************************************/
 
 #ifndef __SNEEDACITY_ADORNED_RULER_PANEL__

--- a/src/menus/ToolbarMenus.cpp
+++ b/src/menus/ToolbarMenus.cpp
@@ -5,6 +5,7 @@
 #include "../commands/CommandContext.h"
 #include "../commands/CommandManager.h"
 #include "../toolbars/ToolManager.h"
+#include "../CommonCommandFlags.h"
 
 /// Namespace for functions for View Toolbar menu
 namespace ToolbarActions {
@@ -19,6 +20,19 @@ struct Handler : CommandHandlerObject {
 void OnResetToolBars(const CommandContext &context)
 {
    ToolManager::OnResetToolBars(context);
+}
+
+void OnEditMode(const CommandContext &context)
+{
+   auto &project = context.project;
+   auto &commandManager = CommandManager::Get( project );
+
+   bool checked = !gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), true);
+   gPrefs->Write(wxT("/GUI/Toolbars/EditMode"), checked);
+   gPrefs->Flush();
+   commandManager.Check(wxT("EditMode"), checked);
+
+   wxTheApp->AddPendingEvent(wxCommandEvent{ EVT_PREFS_UPDATE });
 }
 
 }; // struct Handler
@@ -48,8 +62,11 @@ BaseItemSharedPtr ToolbarsMenu()
    ( FinderScope{ findCommandHandler },
    Section( wxT("Toolbars"),
       Menu( wxT("Toolbars"), XXO("&Toolbars"),
-         Section( "Reset",
+         Section( "Manage",
             /* i18n-hint: (verb)*/
+            Command( wxT("EditMode"), XXO("Edit &Mode (on/off)"),
+                FN(OnEditMode), AudioIONotBusyFlag(),
+                Options{}.CheckTest( wxT("/GUI/Toolbars/EditMode"), true ) ),
             Command( wxT("ResetToolbars"), XXO("Reset Toolb&ars"),
                FN(OnResetToolBars), AlwaysEnabledFlag )
          ),

--- a/src/menus/ToolbarMenus.cpp
+++ b/src/menus/ToolbarMenus.cpp
@@ -1,4 +1,18 @@
+/**********************************************************************
 
+  Sneedacity: A Digital Audio Editor
+
+  ToolbarMenus.cpp
+
+  Copyright (C) 2021 https://github.com/abb128
+  Copyright (C) 1999-2021 Audacity Team
+  Licensed under the GNU GPL v3+
+
+******************************************************************//**
+
+  handles the editing of toolbars
+
+*//*******************************************************************/
 
 #include "../Menus.h"
 #include "../ProjectSettings.h"

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -8,6 +8,10 @@
   Shane T. Mueller
   Leland Lucius
 
+  Copyright (C) 2021 https://github.com/abb128
+  Copyright (C) 1999-2021 Audacity Team
+  Licensed under the GNU GPL v3+
+
   See ToolBar.h for details.
 
 *******************************************************************//**

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -346,6 +346,7 @@ ToolBar::ToolBar( SneedacityProject &project,
    mHSizer = NULL;
    mVisible = false;
    mPositioned = false;
+   mEditMode = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), true);
 
    mGrabber = NULL;
    mResizer = NULL;
@@ -538,10 +539,14 @@ void ToolBar::ReCreateButtons()
       // Create the main sizer
       auto ms = std::make_unique<wxBoxSizer>(wxHORIZONTAL);
 
-      // Create the grabber and add it to the main sizer
-      mGrabber = safenew Grabber(this, mType);
-      ms->Add(mGrabber, 0, wxEXPAND | wxALIGN_LEFT | wxALIGN_TOP | wxRIGHT, 1);
-
+      // Grabber is created only when editing, or when it's undocked
+      // (as otherwise the undocked toolbar can't be moved around)
+      if (mEditMode || !IsDocked())
+      {
+         // Create the grabber and add it to the main sizer
+         mGrabber = safenew Grabber(this, mType);
+         ms->Add(mGrabber, 0, wxEXPAND | wxALIGN_LEFT | wxALIGN_TOP | wxRIGHT, 1);
+      }
       // Use a box sizer for laying out controls
       ms->Add((mHSizer = safenew wxBoxSizer(wxHORIZONTAL)), 1, wxEXPAND);
 
@@ -549,7 +554,7 @@ void ToolBar::ReCreateButtons()
       Populate();
 
       // Add some space for the resize border
-      if (IsResizable())
+      if (mEditMode && IsResizable())
       {
          // Create the resizer and add it to the main sizer
          mResizer = safenew ToolBarResizer(this);
@@ -621,6 +626,21 @@ void ToolBar::UpdatePrefs()
    }
 #endif
 
+   bool updated = false;
+   bool editing = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), true);
+
+   if ( editing != mEditMode )
+   {
+      mEditMode = editing;
+      updated = true;
+   }
+
+   if ( updated )
+   {
+      ReCreateButtons();
+      Updated();
+   }
+
    return;
 }
 
@@ -633,6 +653,15 @@ ToolDock *ToolBar::GetDock()
 }
 
 //
+// Returns whether or not edit mode is enabled
+//
+bool ToolBar::GetEditMode()
+{
+   return mEditMode;
+}
+
+
+//
 // Toggle the docked/floating state
 //
 void ToolBar::SetDocked( ToolDock *dock, bool pushed )
@@ -640,13 +669,16 @@ void ToolBar::SetDocked( ToolDock *dock, bool pushed )
    // Remember it
 //   mDock = dock;
 
-   // Change the tooltip of the grabber
+   if ( mGrabber )
+   {
+      // Change the tooltip of the grabber
 #if wxUSE_TOOLTIPS
-   mGrabber->SetToolTip( GetTitle() );
+      mGrabber->SetToolTip( GetTitle() );
 #endif
 
-   // Set the grabber button state
-   mGrabber->PushButton( pushed );
+      // Set the grabber button state
+      mGrabber->PushButton( pushed );
+   }
 
    if (mResizer)
    {

--- a/src/toolbars/ToolBar.h
+++ b/src/toolbars/ToolBar.h
@@ -8,6 +8,10 @@
   Shane T. Mueller
   Leland Lucius
 
+  Copyright (C) 2021 https://github.com/abb128
+  Copyright (C) 1999-2021 Audacity Team
+  Licensed under the GNU GPL v3+
+
 **********************************************************************/
 
 #ifndef __SNEEDACITY_TOOLBAR__

--- a/src/toolbars/ToolBar.h
+++ b/src/toolbars/ToolBar.h
@@ -121,6 +121,7 @@ class SNEEDACITY_DLL_API ToolBar /* not final */
    TranslatableString GetLabel();
    wxString GetSection();
    ToolDock *GetDock();
+   bool GetEditMode();
 
 private:
    void SetLabel(const wxString & label) override;
@@ -249,6 +250,7 @@ public:
    bool mVisible;
    bool mResizable;
    bool mPositioned; // true if position floating determined.
+   bool mEditMode;
 
  public:
 

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -1177,7 +1177,7 @@ void ToolManager::OnMouse( wxMouseEvent & event )
          DoneDragging();
          return;
       }
-      else if( mDragDock && !event.ShiftDown() )
+      else if( mDragDock && !event.ShiftDown() && mDragBar->GetEditMode() )
       {
          // Trip over...everyone ashore that's going ashore...
          mDragDock->Dock( mDragBar, true, mDragBefore );
@@ -1249,7 +1249,7 @@ void ToolManager::OnMouse( wxMouseEvent & event )
          dock = mBotDock;
 
       // Looks like we have a winner...
-      if( dock )
+      if( dock && mDragBar->GetEditMode() )
       {
          wxPoint p;
          wxRect r;

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -8,6 +8,10 @@
   Shane T. Mueller
   Leland Lucius
 
+  Copyright (C) 2021 https://github.com/abb128
+  Copyright (C) 1999-2021 Audacity Team
+  Licensed under the GNU GPL v3+
+
   See ToolManager.h for details.
 
 *******************************************************************//**


### PR DESCRIPTION
This is from a PR to Tenacity [here](https://github.com/tenacityteam/tenacity/pull/164), credit goes to abb128.
> This implements a new checkbox under View > Toolbars > Edit Mode (on/off), and it is checked ON by default. Unchecking it disables grabbing and resizing toolbars, which makes the user interface slightly cleaner and prevents accidental drags.
> 
> ON (default):
> ![image](https://user-images.githubusercontent.com/65567823/124939763-128a0380-e012-11eb-80bd-5cff4ef2ea37.png)
> 
> OFF:
> ![image](https://user-images.githubusercontent.com/65567823/124939561-e2dafb80-e011-11eb-8cc5-898047e3d74f.png)
> 
> Undocked toolbars continue to have grabbers, but they cannot be docked back with the main window unless edit mode is re-enabled.
> 
> * [x]  The code in this pull request is licensed under "GPLv2 or any later version"*
> * [x]  I made sure the code compiles on my machine
> * [x]  I made sure there are no unnecessary changes in the code*
> * [x]  I made sure the title of the PR reflects the core meaning of the issue you are solving*
> * [x]  I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"*