### PR TITLE
added system theming on windows

### DIFF
--- a/src/SneedacityApp.cpp
+++ b/src/SneedacityApp.cpp
@@ -172,7 +172,35 @@ static void wxOnAssert(const wxChar *fileName, int lineNumber, const wxChar *msg
 #endif
 
 namespace {
+#if _WIN32
+#include <Windows.h>
+    // In case it's not system theme is not defined, return 1 for light theme
+    const char* getSystemTheme() {
+        HKEY resultKey;
+        LONG err = RegOpenKeyEx(HKEY_CURRENT_USER, L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", 0, KEY_READ, &resultKey);
+        if (err != ERROR_SUCCESS)
+        {
+            return "light";
+        }
+        DWORD dataType;
+        WCHAR value[255];
+        PVOID pvdata = value;
+        DWORD size = sizeof(value);
+        err = RegGetValue(resultKey, NULL, L"AppsUseLightTheme", RRF_RT_ANY, &dataType, pvdata, &size);
+        if (err != ERROR_SUCCESS)
+        {
+            return "light";
+        }
 
+        if (*(DWORD*)pvdata == 0) {
+            return "dark";
+        }
+        else {
+            return "light";
+        }
+        RegCloseKey(resultKey);
+    }
+#endif // _WIN32
 void PopulatePreferences()
 {
    bool resetPrefs = false;
@@ -370,6 +398,13 @@ void PopulatePreferences()
       gPrefs->Write(wxT("/GUI/Toolbars/Time/Path"),"0,1");
       gPrefs->Write(wxT("/GUI/Toolbars/Time/Show"),1);
    }
+
+#if _WIN32
+   {
+       auto theme = getSystemTheme();
+       gPrefs->Write(wxT("/Gui/Theme"), theme);
+   }
+#endif // _WIN32
 
    // write out the version numbers to the prefs file for future checking
    gPrefs->Write(wxT("/Version/Major"), SNEEDACITY_VERSION);


### PR DESCRIPTION
Added system theming on windows
I checked it building under x64 and x86 windows, and it worked with both themes, changed, light and dark.

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
