### PR TITLE
automate creation of latest/nightly releases

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -171,7 +171,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: Sneedacity_appimage
+          asset_name: Sneedacity_appimage.AppImage
           asset_path: ${{ steps.linux-artifact.outputs.file }}
           asset_content_type: application/x-executable
 
@@ -181,7 +181,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: Sneedacity_Windows_32bit
+          asset_name: Sneedacity_Windows_32bit.zip
           asset_path: ${{ steps.win32-artifact.outputs.file }}
           asset_content_type: application/zip
 
@@ -191,7 +191,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: Sneedacity_Windows_64bit
+          asset_name: Sneedacity_Windows_64bit.zip
           asset_path: ${{ steps.win64-artifact.outputs.file }}
           asset_content_type: application/zip
 
@@ -201,6 +201,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: Sneedacity_macOS
+          asset_name: Sneedacity_macOS.dmg
           asset_path: ${{ steps.mac-artifact.outputs.file }}
           asset_content_type: application/x-bzip2

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -111,3 +111,96 @@ jobs:
           build/package/*
           !build/package/_CPack_Packages
         if-no-files-found: error
+    
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: Ckath/create-release@v1.2.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: latest-sneed
+          release_name: Latest Sneed
+          body: |
+              Newest working commit on master
+          prerelease: true
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Environment
+        run: |
+          source "scripts/ci/environment.sh"
+
+      - uses: actions/download-artifact@v2.0.10
+        with:
+          name: Sneedacity_Ubuntu_18.04_${{ github.run_id }}_${{ env.GIT_HASH_SHORT }}
+          path: artifacts/
+      - id: linux-artifact
+        run: echo ::set-output name=file::$(ls artifacts/*linux*.AppImage)
+
+      - uses: actions/download-artifact@v2.0.10
+        with:
+          name: Sneedacity_Windows_32bit_${{ github.run_id }}_${{ env.GIT_HASH_SHORT }}
+          path: artifacts/
+      - id: win32-artifact
+        run: echo ::set-output name=file::$(ls artifacts/*win*32bit.zip)
+
+      - uses: actions/download-artifact@v2.0.10
+        with:
+          name: Sneedacity_Windows_64bit_${{ github.run_id }}_${{ env.GIT_HASH_SHORT }}
+          path: artifacts/
+      - id: win64-artifact
+        run: echo ::set-output name=file::$(ls artifacts/*win*64bit.zip)
+
+      - uses: actions/download-artifact@v2.0.10
+        with:
+          name: Sneedacity_macOS_Intel_${{ github.run_id }}_${{ env.GIT_HASH_SHORT }}
+          path: artifacts/
+      - id: mac-artifact
+        run: echo ::set-output name=file::$(ls artifacts/*macos*.dmg)
+
+      - name: Upload release asset (Ubuntu)
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: Sneedacity_appimage
+          asset_path: ${{ steps.linux-artifact.outputs.file }}
+          asset_content_type: application/x-executable
+
+      - name: Upload release asset (Windows 32bit)
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: Sneedacity_Windows_32bit
+          asset_path: ${{ steps.win32-artifact.outputs.file }}
+          asset_content_type: application/zip
+
+      - name: Upload release asset (Windows 64bit)
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: Sneedacity_Windows_64bit
+          asset_path: ${{ steps.win64-artifact.outputs.file }}
+          asset_content_type: application/zip
+
+      - name: Upload release asset (Mac OS)
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: Sneedacity_macOS
+          asset_path: ${{ steps.mac-artifact.outputs.file }}
+          asset_content_type: application/x-bzip2


### PR DESCRIPTION
automates the creation of 'latest' releases from the last time artifacts all built successfully from a commit to master. also mentioned in #145, think it'd be nice to have for sites to link to and to make it clear where they are.

example of how these releases look: https://github.com/Ckath/sneedacity/releases

these releases wont stack up and will just replace the last one at the top under one `latest-sneed` tag. can still do regular manual releases besides it for stable builds.
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
