### PR TITLE
add jack to pkgbuild deps

### DIFF
--- a/pkg/arch/sneedacity-git/.SRCINFO
+++ b/pkg/arch/sneedacity-git/.SRCINFO
@@ -26,6 +26,7 @@ pkgbase = sneedacity-git
 	depends = libid3tag
 	depends = libogg
 	depends = libsndfile
+	depends = jack
 	depends = libvorbis
 	depends = lilv
 	depends = lv2

--- a/pkg/arch/sneedacity-git/PKGBUILD
+++ b/pkg/arch/sneedacity-git/PKGBUILD
@@ -8,7 +8,7 @@ arch=(i686 x86_64)
 url="https://github.com/Sneeds-Feed-and-Seed/sneedacity"
 license=(GPL2 CCPL)
 groups=(sneed-suite)
-depends=(alsa-lib libx11 gtk3 expat libid3tag libogg libsndfile
+depends=(alsa-lib libx11 gtk3 expat libid3tag libogg libsndfile jack
          libvorbis lilv lv2 portsmf suil libmad twolame vamp-plugin-sdk libsoxr soundtouch)
 makedepends=(git cmake sdl2 libsoup libnotify gstreamer gst-plugins-bad-libs
              ffmpeg jack nasm conan)


### PR DESCRIPTION
it links against jack as is but doesnt dep it as regular dep afterwords in the pkgbuild.
possibly more that might be required but thats the one I saw just now.

for the record im innocent here even though I made it, this is just what the upstream audacity pkgbuild had

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
