### PR TITLE
fix linux workaround for coman_removal properly

### DIFF
--- a/cmake-proxies/cmake-modules/CopyLibs.cmake
+++ b/cmake-proxies/cmake-modules/CopyLibs.cmake
@@ -108,11 +108,6 @@ function( gather_libs src )
 
       execute( output sh -c "LD_LIBRARY_PATH='${WXWIN}' ldd ${src}" )
 
-      execute_process( COMMAND
-              bash "-c" 
-              "cp $(ldd ${src} | sed 's/.*> //g;s/ .*//g' | grep sneed) '${WXWIN}'" )
-
-
       get_filename_component( libname "${src}" NAME )
 
       foreach( line ${output} )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1318,7 +1318,7 @@ else()
       COMMAND
          ${CMAKE_COMMAND} -D SRC="${_EXEDIR}/sneedacity"
                           -D DST="${_DEST}/${_PKGLIB}"
-                          -D WXWIN="${_SHARED_PROXY_BASE_PATH}/$<CONFIG>"
+                          -D WXWIN="${CMAKE_BINARY_DIR}/lib"
                           -P ${SNEEDACITY_MODULE_PATH}/CopyLibs.cmake
       POST_BUILD
    )


### PR DESCRIPTION
Resolves: all the places the 'workaround' created issues, mainly the pkgbuild from the conan_removal branch

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
