### PR TITLE
remove useless line from pkgbuild

### DIFF
--- a/pkg/arch/sneedacity-git/PKGBUILD
+++ b/pkg/arch/sneedacity-git/PKGBUILD
@@ -37,7 +37,6 @@ build() {
     sneedacity_use_ffmpeg:STRING=loaded \
     ..
   cmake --build .
-  make .
 }
 
 package() {


### PR DESCRIPTION
also did this in [the one on the aur,](https://aur.archlinux.org/packages/sneedacity-git/) not sure if we want to keep the pkgbuild in this repo now that it seems to be okay on the aur. probably good to keep it equal with the one there for at least a while till its sure it wont be removed again.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
