### PR TITLE
remove mentions of da

### DIFF
--- a/libraries/lib-strings/Internat.cpp
+++ b/libraries/lib-strings/Internat.cpp
@@ -41,8 +41,6 @@ STRINGS_API const wxString& GetCustomSubstitution(const wxString& str1)
    return str1 ;
 }
 
-// In any translated string, we can replace the name 'Sneedacity' by 'DarkSneedacity'
-// without requiring translators to see extra strings for the two versions.
 STRINGS_API const wxString& GetCustomTranslation(const wxString& str1)
 {
    const wxString& str2 = wxGetTranslation( str1 );

--- a/src/Experimental.cmake
+++ b/src/Experimental.cmake
@@ -50,9 +50,6 @@ set( EXPERIMENTAL_OPTIONS_LIST
    # feature to link audio tracks to a label track
    SYNC_LOCK
 
-   # DA: Enables dark sneedacity theme and customisations.
-   #DA
-
    # Define this so that sync-lock tiles shine through spectrogram.
    # The spectrogram pastes a bitmap over the tiles.
    # This makes it use alpha blending, most transparent where least intense.


### PR DESCRIPTION
found a couple more mentions of DA which has been scrapped since #183, these are the final mentions of it gone (besides all those locale/ files I've been avoiding thinking about)
*(short description of the changes and the motivation to make the changes)*

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
