### PR TITLE
attempt to fix the random macos package fails

### DIFF
--- a/scripts/ci/package.sh
+++ b/scripts/ci/package.sh
@@ -9,7 +9,10 @@ cd build
 if [[ "${OSTYPE}" == msys* && ${GIT_BRANCH} == release* ]]; then # Windows
     cmake --build . --target innosetup --config "${SNEEDACITY_BUILD_TYPE}"
 else
-    cpack -C "${SNEEDACITY_BUILD_TYPE}" --verbose
+    set +e
+    cpack -C "${SNEEDACITY_BUILD_TYPE}" --verbose ||
+    (set -e ; echo "build failed, trying one more time" ;
+    cpack -C "${SNEEDACITY_BUILD_TYPE}" --verbose)
 fi
 
 # Remove the temporary directory


### PR DESCRIPTION
Resolves: those mac builds dying randomly on package, maybe
this is a very stupid solution to a very stupid issue, I've yet to test if this fixes the failure cases because it refused to act up on my branch.

hopefully within this pr they'll die and recover to proof this stupid 'fix' works, if it doesnt I can at least use it as place for people to suggest better solutions. it should get around these:
![image](https://user-images.githubusercontent.com/15038414/126690578-cc159f01-dcf0-41f1-90ea-a659223b2f05.png)