### PR TITLE
Reduce the time spent downloading sccache via using curl with an artifact rather than scoop

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -86,7 +86,7 @@ jobs:
         cd C:/sccache
         curl.exe -LO "$LINK"
         unzip.exe *
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        echo "C:/sccache" >> $GITHUB_PATH
 
     - name: "Set up compiler cache"
       uses: actions/cache@v2

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -79,7 +79,14 @@ jobs:
 
     - name: "Install sccache"
       if: startswith( matrix.config.os, 'windows' )
-      run: choco install sccache
+      env:
+          LINK: https://nightly.link/mozilla/sccache/actions/runs/814676514/sccache-0f90d53a991ea8e4867667a06006169617354a5e-x86_64-pc-windows-msvc.zip
+      run: |
+        mkdir C:/sccache
+        cd C:/sccache
+        curl.exe -LO "$LINK"
+        unzip.exe *
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: "Set up compiler cache"
       uses: actions/cache@v2


### PR DESCRIPTION
Before this, sccache installation was taking 1.5 minutes, now it takes 5 seconds.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
