### PR TITLE
add aur package github action

### DIFF
--- a/.github/workflows/pkgbuild.yml
+++ b/.github/workflows/pkgbuild.yml
@@ -1,0 +1,30 @@
+name: Make PKGBUILD
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pkgbuild-validate:
+    runs-on: ubuntu-latest
+    name: Build arch package
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare PKGBUILD
+        run: |
+          sed -i 's/sneedacity-git/sneedacity-bin/g' pkg/arch/sneedacity-git/PKGBUILD
+          rm pkg/arch/sneedacity-git/.SRCINFO
+
+      - name: Build sneedacity-bin
+        id: makepkg
+        uses: edlanglois/pkgbuild-action@v1
+        with:
+          pkgdir: 'pkg/arch/sneedacity-git'
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: sneedacity-arch-pkg
+          path: "${{ steps.makepkg.outputs.pkgfile0 }}"


### PR DESCRIPTION
Been meaning to look into this, turns out it wasnt that bad to setup. [see result here](https://github.com/Ckath/sneedacity/actions/runs/1201044218)
possible considerations here:

- add sscache to it (honestly never helps me)
- instead of using a new workflow and a dedicated action tape it into the main build sh
- rename the workflow to 'packaging' or something generic to also use it for future deb and whatnot other distro packages
- do this from the arch bin repo git instead of here

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
