### PR TITLE
drop jack as makedep, already regular dep

### DIFF
--- a/pkg/arch/sneedacity-git/.SRCINFO
+++ b/pkg/arch/sneedacity-git/.SRCINFO
@@ -16,7 +16,6 @@ pkgbase = sneedacity-git
 	makedepends = gstreamer
 	makedepends = gst-plugins-bad-libs
 	makedepends = ffmpeg
-	makedepends = jack
 	makedepends = nasm
 	depends = alsa-lib
 	depends = libx11

--- a/pkg/arch/sneedacity-git/PKGBUILD
+++ b/pkg/arch/sneedacity-git/PKGBUILD
@@ -11,7 +11,7 @@ groups=(sneed-suite)
 depends=(alsa-lib libx11 gtk3 expat libid3tag libogg libsndfile jack
          libvorbis lilv lv2 portsmf suil libmad twolame vamp-plugin-sdk libsoxr soundtouch)
 makedepends=(git cmake sdl2 libsoup libnotify gstreamer gst-plugins-bad-libs
-             ffmpeg jack nasm)
+             ffmpeg nasm)
 # can't find system lame portmidi
 optdepends=('ffmpeg: additional import/export capabilities')
 provides=(audacity sneedacity)


### PR DESCRIPTION
jack doesnt need to be a makedep when its already a dep, the shitty pkgbuild action is right:
![image](https://user-images.githubusercontent.com/15038414/132103689-6e167594-3936-4329-bf53-ae04b812d63f.png)
now if we should be happy about it building against jack when it also has the option to not do that is another question. can imagine not wanting to install jack just to use sneedacity.
possible point to reconsider default build options?

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
