### PR TITLE
Fix Mac build crashes #297

### DIFF
--- a/mac/Wrapper.c
+++ b/mac/Wrapper.c
@@ -43,8 +43,9 @@ int main(int argc, char *argv[])
    char *slash = strrchr(path, '/');
    if (slash)
    {
-      strncpy(++slash, sneedacity, exlen);
+       strncpy(++slash, sneedacity, SNEEDACITY_LEN);
    }
+   argv[0] = path; // argv[0] should now also be the Sneedacity path, not the Wrapper path
 
    unsetenv("DYLD_LIBRARY_PATH");
 


### PR DESCRIPTION
Mac Wrapper: only strncpy SNEEDACITY_LEN bytes and set argv[0] to new path

Resolves: [Mac build crashes #297](https://github.com/Sneeds-Feed-and-Seed/sneedacity/issues/297)

In the Mac Wrapper, `mac/Wrapper.c` this line:
```c
strncpy(++slash, sneedacity, exlen);
```
was copying far too many characters (e.g. 94, on my system) in order to just copy the string "Sneedacity\0", and padding with zeros, which was corrupting the stack and leading to different behaviours in different environments - not running the main app at all in Xcode, crashing when the app bundle was run from Finder, and working successfully when `Wrapper` was called from the terminal.

I changed the length given to strncpy to SNEEDACITY_LEN (11):
```c
strncpy(++slash, sneedacity, SNEEDACITY_LEN);
```
and also set argv[0] to the new path now ending in "Sneedacity" rather than "Wrapper"
```c
argv[0] = path;
```

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I have confirmed that my code does not introduce intentional security flaws 
